### PR TITLE
chore(templates): fixes bug in e-commerce

### DIFF
--- a/templates/ecommerce/package.json
+++ b/templates/ecommerce/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "cross-env PAYLOAD_CONFIG_PATH=src/payload/payload.config.ts nodemon",
-    "stripe:webhooks": "stripe listen --forward-to localhost:8000/stripe/webhooks",
+    "stripe:webhooks": "stripe listen --forward-to localhost:3000/stripe/webhooks",
     "seed": "rm -rf media && cross-env PAYLOAD_SEED=true PAYLOAD_DROP_DATABASE=true PAYLOAD_CONFIG_PATH=src/payload/payload.config.ts ts-node src/server.ts",
     "build:payload": "cross-env PAYLOAD_CONFIG_PATH=src/payload/payload.config.ts payload build",
     "build:server": "tsc --project tsconfig.server.json",


### PR DESCRIPTION
## Description

When following the documentation to run the E Commerce template locally, you are asked to run `yarn stripe:webhooks` to work with webhooks.

However, when checking out your cart and a webhook is triggered, your terminal receives the following error: 

```
[ERROR] Failed to POST: Post "http://localhost:8000/stripe/webhooks": dial tcp 127.0.0.1:8000: connect: connection refused
```

I believe this is because the port is wrong, and it should be port `3000`. There is no reference to a port `8000` anywhere in the code base for this template, including in the docker-compose.yml file.

Making this changes allows webhook requests to be forwarded correctly:

```
--> customer.created [evt_...]
<-- [200] POST http://localhost:3000/stripe/webhooks [evt_...]
```

This PR makes this small change.

<!-- Please include a summary of the pull request and any related issues it fixes. Please also include relevant motivation and context. -->

- [x] I have read and understand the [CONTRIBUTING.md](https://github.com/payloadcms/payload/blob/main/CONTRIBUTING.md) document in this repository.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Change to the [templates](https://github.com/payloadcms/payload/tree/main/templates) directory (does not affect core functionality)

## Checklist:

- [x] Existing test suite passes locally with my changes
